### PR TITLE
Expo 50 SDK Compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,13 +53,16 @@ afterEvaluate {
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 34)
 
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
-  }
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  if (agpVersion.tokenize('.')[0].toInteger() < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
 
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.majorVersion
+    kotlinOptions {
+      jvmTarget = JavaVersion.VERSION_11.majorVersion
+    }
   }
 
   namespace "expo.modules.enodelinksdk"

--- a/ios/ExpoEnodeLinkSDK.podspec
+++ b/ios/ExpoEnodeLinkSDK.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '13.0'
+  s.platform       = :ios, '13.4'
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/YoussefHenna/expo-enode-link-sdk' }
   s.static_framework = true


### PR DESCRIPTION
closes #8 

> [!WARNING] 
> ~~I haven't actually tested this, `eas-cli build` didn't really want to play ball when I `yarn add`'ed my fork. (Seems like yarn is not happy with the [prepare](https://github.com/yarnpkg/yarn/issues/7212#issuecomment-493720324) script in the git added module)~~

Changes made according to [expo sdk 50 upgrade readme](https://expo.dev/changelog/2024/01-18-sdk-50#%E2%9E%A1%EF%B8%8F-upgrading-your-app).

Seems like the recommended upgrade is to add a check for `ANDROID_GRADLE_PLUGIN_VERSION`, so I'm **_guessing_** it's backwards compatible with Expo SDK 49.

Relevant section:
> - If you maintain any Expo Modules:
>   - For Android: update your library build.gradle to match the changes in [this diff](https://gist.github.com/brentvatne/61cd1a938fb4ba8869bc490647aa52e8). You may also now remove the JVM target version configuration, [as explained in this FYI page](https://expo.fyi/expo-modules-gradle8-migration#error-task-current-target-is-17-and-compilereleasekotlin-task-current-target-is-11-jvm-target-compatibility-should-be-set-to-the-same-java-version).
>   - For iOS: update the platform deployment target field from '13.0' to '13.4', matching the changes in [this diff](https://gist.github.com/brentvatne/87ac1b2c402be415972231a73ba3a695).
